### PR TITLE
update concat-stream example to use mississippi

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -306,13 +306,11 @@ Note that `miss.concat` will not handle stream errors for you. To handle errors,
 
 ```js
 var fs = require('fs')
-var concat = require('concat-stream')
 
 var readStream = fs.createReadStream('cat.png')
-var concatStream = concat(gotPicture)
+var concatStream = miss.concat(gotPicture)
 
-readStream.on('error', handleError)
-readStream.pipe(concatStream)
+miss.pipe(readStream, concatStream, handleError)
 
 function gotPicture(imageBuffer) {
   // imageBuffer is all of `cat.png` as a node.js Buffer

--- a/readme.md
+++ b/readme.md
@@ -310,7 +310,14 @@ var fs = require('fs')
 var readStream = fs.createReadStream('cat.png')
 var concatStream = miss.concat(gotPicture)
 
-miss.pipe(readStream, concatStream, handleError)
+function callback (err) {
+  if (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}
+
+miss.pipe(readStream, concatStream, callback)
 
 function gotPicture(imageBuffer) {
   // imageBuffer is all of `cat.png` as a node.js Buffer


### PR DESCRIPTION
The concat-stream example was not using mississippi. This updates it to use `miss.concat()` and `miss.pipe()`.

cc @jlord 👋 
