### PR TITLE
Add pipeline.obj example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,8 @@ function done (err) {
 
 Builds a pipeline from all the transform streams passed in as arguments by piping them together and returning a single stream object that lets you write to the first stream and read from the last stream.
 
+If you are pumping object streams together use `pipeline = miss.pipeline.obj(s1, s2, ...)`. 
+
 If any of the streams in the pipeline emits an error or gets destroyed, or you destroy the stream it returns, all of the streams will be destroyed and cleaned up for you.
 
 #### original module


### PR DESCRIPTION
Suggestion to add an example about `pipeline.obj`
