### PR TITLE
fix pump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "flush-write-stream": "^1.0.0",
     "from2": "^2.1.0",
     "parallel-transform": "^1.1.0",
-    "pump": "^2.0.1",
+    "pump": "^3.0.0",
     "pumpify": "^1.3.3",
     "stream-each": "^1.1.0",
     "through2": "^2.0.0"


### PR DESCRIPTION
In version 2.0.1 Pump has removed the return statement used in miss.pipe ...
The statement has been put back in version 3.0.0 ...