### PR TITLE
Use `binary-split` instead of `split2`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Optionally you can call `next` with an error to destroy the stream. You can also
 
 ```js
 var fs = require('fs')
-var split = require('split2')
+var split = require('binary-split')
 
 var newLineSeparatedNumbers = fs.createReadStream('numbers.txt')
 

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Optionally you can call `next` with an error to destroy the stream. You can also
 
 ```js
 var fs = require('fs')
-var split = require('binary-split')
+var split = require('binary-split') // require('split2') would work here as well
 
 var newLineSeparatedNumbers = fs.createReadStream('numbers.txt')
 


### PR DESCRIPTION
Practically both are the same and follow the same interface, but `binary-split` allows you to work with binary data as well.

Also, the example is calling `.toString()`, so now is more explicit what you are expecting from the stream